### PR TITLE
#22 Rename Query gateway extension methods

### DIFF
--- a/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensions.kt
+++ b/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensions.kt
@@ -60,7 +60,7 @@ inline fun <reified R, reified Q> QueryGateway.queryMany(queryName: String, quer
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.querySingle(query: Q): CompletableFuture<R> {
+inline fun <reified R, reified Q> QueryGateway.query(query: Q): CompletableFuture<R> {
     return this.query(query, ResponseTypes.instanceOf(R::class.java))
 }
 
@@ -75,7 +75,7 @@ inline fun <reified R, reified Q> QueryGateway.querySingle(query: Q): Completabl
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.querySingle(queryName: String, query: Q): CompletableFuture<R> {
+inline fun <reified R, reified Q> QueryGateway.query(queryName: String, query: Q): CompletableFuture<R> {
     return this.query(queryName, query, ResponseTypes.instanceOf(R::class.java))
 }
 

--- a/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensions.kt
+++ b/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensions.kt
@@ -31,7 +31,7 @@ import java.util.concurrent.CompletableFuture
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.queryForMultiple(query: Q): CompletableFuture<List<R>> {
+inline fun <reified R, reified Q> QueryGateway.queryMany(query: Q): CompletableFuture<List<R>> {
     return this.query(query, ResponseTypes.multipleInstancesOf(R::class.java))
 }
 
@@ -46,7 +46,7 @@ inline fun <reified R, reified Q> QueryGateway.queryForMultiple(query: Q): Compl
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.queryForMultiple(queryName: String, query: Q): CompletableFuture<List<R>> {
+inline fun <reified R, reified Q> QueryGateway.queryMany(queryName: String, query: Q): CompletableFuture<List<R>> {
     return this.query(queryName, query, ResponseTypes.multipleInstancesOf(R::class.java))
 }
 
@@ -60,7 +60,7 @@ inline fun <reified R, reified Q> QueryGateway.queryForMultiple(queryName: Strin
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.queryForSingle(query: Q): CompletableFuture<R> {
+inline fun <reified R, reified Q> QueryGateway.querySingle(query: Q): CompletableFuture<R> {
     return this.query(query, ResponseTypes.instanceOf(R::class.java))
 }
 
@@ -75,7 +75,7 @@ inline fun <reified R, reified Q> QueryGateway.queryForSingle(query: Q): Complet
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.queryForSingle(queryName: String, query: Q): CompletableFuture<R> {
+inline fun <reified R, reified Q> QueryGateway.querySingle(queryName: String, query: Q): CompletableFuture<R> {
     return this.query(queryName, query, ResponseTypes.instanceOf(R::class.java))
 }
 
@@ -89,7 +89,7 @@ inline fun <reified R, reified Q> QueryGateway.queryForSingle(queryName: String,
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.queryForOptional(query: Q): CompletableFuture<Optional<R>> {
+inline fun <reified R, reified Q> QueryGateway.queryOptional(query: Q): CompletableFuture<Optional<R>> {
     return this.query(query, ResponseTypes.optionalInstanceOf(R::class.java))
 }
 
@@ -104,6 +104,6 @@ inline fun <reified R, reified Q> QueryGateway.queryForOptional(query: Q): Compl
  * @see QueryGateway.query
  * @see ResponseTypes
  */
-inline fun <reified R, reified Q> QueryGateway.queryForOptional(queryName: String, query: Q): CompletableFuture<Optional<R>> {
+inline fun <reified R, reified Q> QueryGateway.queryOptional(queryName: String, query: Q): CompletableFuture<Optional<R>> {
     return this.query(queryName, query, ResponseTypes.optionalInstanceOf(R::class.java))
 }

--- a/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
@@ -61,7 +61,7 @@ class QueryGatewayExtensionsTest {
 
     @Test
     fun `Query without queryName Single should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.querySingle<String, ExampleQuery>(query = exampleQuery)
+        val queryResult = subjectGateway.query<String, ExampleQuery>(query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) {
             subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java))
@@ -70,7 +70,7 @@ class QueryGatewayExtensionsTest {
 
     @Test
     fun `Query without queryName Single should invoke query method and not require explicit generic types`() {
-        val queryResult:CompletableFuture<String> = subjectGateway.querySingle(query = exampleQuery)
+        val queryResult:CompletableFuture<String> = subjectGateway.query(query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) {
             subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java))
@@ -116,7 +116,7 @@ class QueryGatewayExtensionsTest {
             every { query(exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
         }
 
-        val queryResult = nullableQueryGateway.querySingle<String?, ExampleQuery>(query = exampleQuery)
+        val queryResult = nullableQueryGateway.query<String?, ExampleQuery>(query = exampleQuery)
 
         assertSame(queryResult, nullInstanceReturnValue)
         assertTrue(nullInstanceReturnValue.get() == null)
@@ -126,15 +126,14 @@ class QueryGatewayExtensionsTest {
 
     @Test
     fun `Query Single should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.querySingle<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
-
+        val queryResult = subjectGateway.query<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
     fun `Query Single should invoke query method and not require explicit generic types`() {
-        val queryResult: CompletableFuture<String> = subjectGateway.querySingle(queryName = queryName, query = exampleQuery)
+        val queryResult: CompletableFuture<String> = subjectGateway.query(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
@@ -179,7 +178,7 @@ class QueryGatewayExtensionsTest {
             every { query(queryName, exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
         }
 
-        val queryResult = nullableQueryGateway.querySingle<String?, ExampleQuery>(queryName = queryName, query = exampleQuery)
+        val queryResult = nullableQueryGateway.query<String?, ExampleQuery>(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, nullInstanceReturnValue)
         assertTrue(nullInstanceReturnValue.get() == null)

--- a/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
@@ -60,7 +60,7 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query without queryName Single should invoke query method with correct generic parameters`() {
+    fun `Query without queryName should invoke query method with correct generic parameters`() {
         val queryResult = subjectGateway.query<String, ExampleQuery>(query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) {
@@ -69,7 +69,7 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query without queryName Single should invoke query method and not require explicit generic types`() {
+    fun `Query without queryName should invoke query method and not require explicit generic types`() {
         val queryResult:CompletableFuture<String> = subjectGateway.query(query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) {
@@ -110,7 +110,7 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query without queryName Single should handle nullable responses`() {
+    fun `Query without queryName should handle nullable responses`() {
         val nullInstanceReturnValue: CompletableFuture<String?> = CompletableFuture.completedFuture(null)
         val nullableQueryGateway = mockk<QueryGateway> {
             every { query(exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
@@ -125,14 +125,14 @@ class QueryGatewayExtensionsTest {
 
 
     @Test
-    fun `Query Single should invoke query method with correct generic parameters`() {
+    fun `Query should invoke query method with correct generic parameters`() {
         val queryResult = subjectGateway.query<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query Single should invoke query method and not require explicit generic types`() {
+    fun `Query should invoke query method and not require explicit generic types`() {
         val queryResult: CompletableFuture<String> = subjectGateway.query(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, instanceReturnValue)
@@ -172,7 +172,7 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query Single should handle nullable responses`() {
+    fun `Query should handle nullable responses`() {
         val nullInstanceReturnValue: CompletableFuture<String?> = CompletableFuture.completedFuture(null)
         val nullableQueryGateway = mockk<QueryGateway> {
             every { query(queryName, exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue

--- a/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
@@ -60,8 +60,8 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query without queryName for Single should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.queryForSingle<String, ExampleQuery>(query = exampleQuery)
+    fun `Query without queryName Single should invoke query method with correct generic parameters`() {
+        val queryResult = subjectGateway.querySingle<String, ExampleQuery>(query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) {
             subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java))
@@ -69,8 +69,8 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query without queryName for Single should invoke query method and not require explicit generic types`() {
-        val queryResult:CompletableFuture<String> = subjectGateway.queryForSingle(query = exampleQuery)
+    fun `Query without queryName Single should invoke query method and not require explicit generic types`() {
+        val queryResult:CompletableFuture<String> = subjectGateway.querySingle(query = exampleQuery)
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) {
             subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java))
@@ -78,45 +78,45 @@ class QueryGatewayExtensionsTest {
     }
 
     @Test
-    fun `Query without queryName for Optional should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.queryForOptional<String, ExampleQuery>(query = exampleQuery)
+    fun `Query without queryName Optional should invoke query method with correct generic parameters`() {
+        val queryResult = subjectGateway.queryOptional<String, ExampleQuery>(query = exampleQuery)
 
         assertSame(queryResult, optionalReturnValue)
         verify(exactly = 1) { subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query without queryName for Optional should invoke query method and not require explicit generic types`() {
-        val queryResult: CompletableFuture<Optional<String>> = subjectGateway.queryForOptional(query = exampleQuery)
+    fun `Query without queryName Optional should invoke query method and not require explicit generic types`() {
+        val queryResult: CompletableFuture<Optional<String>> = subjectGateway.queryOptional(query = exampleQuery)
 
         assertSame(queryResult, optionalReturnValue)
         verify(exactly = 1) { subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query without queryName for Multiple should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.queryForMultiple<String, ExampleQuery>(query = exampleQuery)
+    fun `Query without queryName Multiple should invoke query method with correct generic parameters`() {
+        val queryResult = subjectGateway.queryMany<String, ExampleQuery>(query = exampleQuery)
 
         assertSame(queryResult, listReturnValue)
         verify(exactly = 1) { subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query without queryName for Multiple should invoke query method and not require explicit generic types`() {
-        val queryResult: CompletableFuture<List<String>> = subjectGateway.queryForMultiple(query = exampleQuery)
+    fun `Query without queryName Multiple should invoke query method and not require explicit generic types`() {
+        val queryResult: CompletableFuture<List<String>> = subjectGateway.queryMany(query = exampleQuery)
 
         assertSame(queryResult, listReturnValue)
         verify(exactly = 1) { subjectGateway.query(exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query without queryName for Single should handle nullable responses`() {
+    fun `Query without queryName Single should handle nullable responses`() {
         val nullInstanceReturnValue: CompletableFuture<String?> = CompletableFuture.completedFuture(null)
         val nullableQueryGateway = mockk<QueryGateway> {
             every { query(exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
         }
 
-        val queryResult = nullableQueryGateway.queryForSingle<String?, ExampleQuery>(query = exampleQuery)
+        val queryResult = nullableQueryGateway.querySingle<String?, ExampleQuery>(query = exampleQuery)
 
         assertSame(queryResult, nullInstanceReturnValue)
         assertTrue(nullInstanceReturnValue.get() == null)
@@ -125,61 +125,61 @@ class QueryGatewayExtensionsTest {
 
 
     @Test
-    fun `Query for Single should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.queryForSingle<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
+    fun `Query Single should invoke query method with correct generic parameters`() {
+        val queryResult = subjectGateway.querySingle<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query for Single should invoke query method and not require explicit generic types`() {
-        val queryResult: CompletableFuture<String> = subjectGateway.queryForSingle(queryName = queryName, query = exampleQuery)
+    fun `Query Single should invoke query method and not require explicit generic types`() {
+        val queryResult: CompletableFuture<String> = subjectGateway.querySingle(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, instanceReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query for Optional should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.queryForOptional<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
+    fun `Query Optional should invoke query method with correct generic parameters`() {
+        val queryResult = subjectGateway.queryOptional<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, optionalReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query for Optional should invoke query method and not require explicit generic types`() {
-        val queryResult: CompletableFuture<Optional<String>> = subjectGateway.queryForOptional(queryName = queryName, query = exampleQuery)
+    fun `Query Optional should invoke query method and not require explicit generic types`() {
+        val queryResult: CompletableFuture<Optional<String>> = subjectGateway.queryOptional(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, optionalReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query for Multiple should invoke query method with correct generic parameters`() {
-        val queryResult = subjectGateway.queryForMultiple<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
+    fun `Query Multiple should invoke query method with correct generic parameters`() {
+        val queryResult = subjectGateway.queryMany<String, ExampleQuery>(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, listReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query for Multiple should invoke query method and not require explicit generic types`() {
-        val queryResult: CompletableFuture<List<String>> = subjectGateway.queryForMultiple(queryName = queryName, query = exampleQuery)
+    fun `Query Multiple should invoke query method and not require explicit generic types`() {
+        val queryResult: CompletableFuture<List<String>> = subjectGateway.queryMany(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, listReturnValue)
         verify(exactly = 1) { subjectGateway.query(queryName, exampleQuery, matchExpectedResponseType(String::class.java)) }
     }
 
     @Test
-    fun `Query for Single should handle nullable responses`() {
+    fun `Query Single should handle nullable responses`() {
         val nullInstanceReturnValue: CompletableFuture<String?> = CompletableFuture.completedFuture(null)
         val nullableQueryGateway = mockk<QueryGateway> {
             every { query(queryName, exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
         }
 
-        val queryResult = nullableQueryGateway.queryForSingle<String?, ExampleQuery>(queryName = queryName, query = exampleQuery)
+        val queryResult = nullableQueryGateway.querySingle<String?, ExampleQuery>(queryName = queryName, query = exampleQuery)
 
         assertSame(queryResult, nullInstanceReturnValue)
         assertTrue(nullInstanceReturnValue.get() == null)


### PR DESCRIPTION
This PR resolves #22

In addition to renaming `Multiple` to `Many`, `For` has also been removed from method names.