### PR TITLE
Add reified generics based extension of QueryUpdateEmitter's emit

### DIFF
--- a/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryUpdateEmitterExtensions.kt
+++ b/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryUpdateEmitterExtensions.kt
@@ -15,6 +15,7 @@ import org.axonframework.queryhandling.QueryUpdateEmitter
  * @param [Q]       the type of the query
  * @param [U]       the type of the update
  * @see org.axonframework.queryhandling.QueryUpdateEmitter.emit
+ * @author Stefan Andjelkovic
  */
 inline fun <reified Q, reified U : Any> QueryUpdateEmitter.emit(update: U, noinline filter: (Q) -> Boolean) =
         this.emit(Q::class.java, filter, update)

--- a/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryUpdateEmitterExtensions.kt
+++ b/kotlin/src/main/kotlin/org/axonframework/extensions/kotlin/QueryUpdateEmitterExtensions.kt
@@ -1,0 +1,22 @@
+package org.axonframework.extensions.kotlin
+
+import org.axonframework.queryhandling.QueryUpdateEmitter
+
+/**
+ * Reified version of [org.axonframework.queryhandling.QueryUpdateEmitter.emit] which uses generics
+ * to indicate Query type and Update type.
+ *
+ * Emits given incremental update to subscription queries matching given generic query type and filter.
+ * In order to send nullable updates, use [org.axonframework.queryhandling.QueryUpdateEmitter.emit]
+ * with an [org.axonframework.queryhandling.SubscriptionQueryUpdateMessage]
+ *
+ * @param update    incremental update
+ * @param filter    predicate on query payload used to filter subscription queries
+ * @param [Q]       the type of the query
+ * @param [U]       the type of the update
+ * @see org.axonframework.queryhandling.QueryUpdateEmitter.emit
+ */
+inline fun <reified Q, reified U : Any> QueryUpdateEmitter.emit(update: U, noinline filter: (Q) -> Boolean) =
+        this.emit(Q::class.java, filter, update)
+
+

--- a/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryUpdateEmitterExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryUpdateEmitterExtensionsTest.kt
@@ -1,0 +1,30 @@
+package org.axonframework.extensions.kotlin
+
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import org.axonframework.queryhandling.QueryUpdateEmitter
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+
+/**
+ * Tests [org.axonframework.queryhandling.QueryUpdateEmitter] extensions.
+ *
+ * @author Stefan Andjelkovic
+ */
+internal class QueryUpdateEmitterExtensionsTest {
+    private val subjectEmitter = mockk<QueryUpdateEmitter>()
+    private val exampleQuery = ExampleQuery(2)
+    private val exampleUpdatePayload: String = "Updated"
+
+    @BeforeTest
+    fun before() {
+        every { subjectEmitter.emit(ExampleQuery::class.java, match { it.test(exampleQuery) }, exampleUpdatePayload) } returns Unit
+    }
+
+    @Test
+    fun `Emit extension should invoke correct emit method with a class parameter`() {
+        subjectEmitter.emit<ExampleQuery, String>(exampleUpdatePayload) { it.value == exampleQuery.value }
+        verify { subjectEmitter.emit(ExampleQuery::class.java, match { it.test(exampleQuery) }, exampleUpdatePayload) }
+    }
+}


### PR DESCRIPTION
This PR resolves #21 

One extension is introduced to use generics instead of class objects for the Query, but due to current limitation in Kotlin's generics, both Query and Update type have to be provided when calling the method.

Filter moved to be the last parameter, to enable Kotlin's syntax for passing lambdas as a method parameter outside of function invocation parentheses.