### PR TITLE
Fix compilation issues in tests after Kotlin 1.4 upgrade

### DIFF
--- a/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
+++ b/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/QueryGatewayExtensionsTest.kt
@@ -113,7 +113,7 @@ internal class QueryGatewayExtensionsTest {
     fun `Query without queryName should handle nullable responses`() {
         val nullInstanceReturnValue: CompletableFuture<String?> = CompletableFuture.completedFuture(null)
         val nullableQueryGateway = mockk<QueryGateway> {
-            every { query(exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
+            every { query(exampleQuery, matchInstanceResponseType<String?>()) } returns nullInstanceReturnValue
         }
 
         val queryResult = nullableQueryGateway.query<String?, ExampleQuery>(query = exampleQuery)
@@ -175,7 +175,7 @@ internal class QueryGatewayExtensionsTest {
     fun `Query should handle nullable responses`() {
         val nullInstanceReturnValue: CompletableFuture<String?> = CompletableFuture.completedFuture(null)
         val nullableQueryGateway = mockk<QueryGateway> {
-            every { query(queryName, exampleQuery, match { i: AbstractResponseType<String?> -> i is InstanceResponseType }) } returns nullInstanceReturnValue
+            every { query(queryName, exampleQuery, matchInstanceResponseType<String?>() ) } returns nullInstanceReturnValue
         }
 
         val queryResult = nullableQueryGateway.query<String?, ExampleQuery>(queryName = queryName, query = exampleQuery)


### PR DESCRIPTION
This PR will fix compilation problems in QueryGatewayExtensions tests. In one of the versions after Kotlin 1.61 type inference engine changed and couldn't handle how Mockk's match was used.