### PR TITLE
Expect KClass exception in tests

### DIFF
--- a/kotlin-test/pom.xml
+++ b/kotlin-test/pom.xml
@@ -21,6 +21,12 @@
       <artifactId>axon-test</artifactId>
       <scope>provided</scope>
     </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-core</artifactId>
+      <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/kotlin-test/src/main/kotlin/org/axonframework/extension/kotlin/test/FixtureExtensions.kt
+++ b/kotlin-test/src/main/kotlin/org/axonframework/extension/kotlin/test/FixtureExtensions.kt
@@ -104,3 +104,13 @@ inline fun <T : Any, reified I : Any> SagaTestFixture<T>.registerCommandGateway(
 inline fun <T : Any, reified I : Any> SagaTestFixture<T>.registerCommandGateway(stubImplementation: I): I =
         this.registerCommandGateway(I::class.java, stubImplementation)
 
+/**
+ * Expect a KClass exception for aggregate [T].
+ * @param T aggregate type
+ * @param E exception type
+ * @param expectedException kotlin class of the exception
+ * @return this
+ * @since 0.2.0
+ */
+fun <T : Any, E : KClass<out Throwable>> ResultValidator<T>.expectException(expectedException: E): ResultValidator<T> =
+        this.expectException(expectedException.java)

--- a/kotlin-test/src/test/kotlin/org/axonframework/extension/kotlin/test/FixtureExtensionsTest.kt
+++ b/kotlin-test/src/test/kotlin/org/axonframework/extension/kotlin/test/FixtureExtensionsTest.kt
@@ -1,0 +1,15 @@
+package org.axonframework.extension.kotlin.test
+
+import org.axonframework.test.aggregate.AggregateTestFixture
+import kotlin.test.Test
+
+internal class FixtureExtensionsTest {
+
+    @Test
+    fun `Expect exception extension should accept a kotlin class`() {
+        val fixture = AggregateTestFixture(ExampleAggregate::class.java)
+        fixture
+                .`when`(ExampleCommand("id"))
+                .expectException(Exception::class)
+    }
+}

--- a/kotlin-test/src/test/kotlin/org/axonframework/extension/kotlin/test/testObjects.kt
+++ b/kotlin-test/src/test/kotlin/org/axonframework/extension/kotlin/test/testObjects.kt
@@ -1,0 +1,20 @@
+package org.axonframework.extension.kotlin.test
+
+import org.axonframework.commandhandling.CommandHandler
+import org.axonframework.commandhandling.RoutingKey
+import org.axonframework.modelling.command.AggregateIdentifier
+
+internal data class ExampleCommand(@RoutingKey val aggregateId: String)
+
+internal class ExampleAggregate {
+
+    @AggregateIdentifier
+    lateinit var aggregateId: String
+
+    constructor()
+
+    @CommandHandler
+    constructor(command: ExampleCommand) {
+        throw Exception()
+    }
+}


### PR DESCRIPTION
This follows up #67 (and the associated PR #73) and changes the way to expect exception in tests.

The current behaviour is:
```
fixture
//    .given(...)
//    .whenever(...)
    .expectException(MyException::class.java)
```

This commit make it possible to use a KClass instead of a Java class:
```
fixture
//    .given(...)
//    .whenever(...)
    .expectException(MyException::class) // <-- change here, no .java
```

This version looks more straightforward and readable to me. What do you think ?