### PR TITLE
Kotlin 1.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <axon.version>4.5</axon.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.4.32</kotlin.version>
+    <kotlin.version>1.5.0</kotlin.version>
     <kotlin-logging.version>2.0.6</kotlin-logging.version>
     <jackson-kotlin.version>2.12.3</jackson-kotlin.version>
     <mockk.version>1.11.0</mockk.version>


### PR DESCRIPTION
Kotlin 1.5 has been released, see https://blog.jetbrains.com/kotlin/2021/05/kotlin-1-5-0-released/

This paves the way for using the stable version of `kotlin.serizliation` for https://github.com/AxonFramework/extension-kotlin/issues/13