### PR TITLE
Add `kotlin.serialization` implementation of `Serializer`

### DIFF
--- a/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/serialization/KotlinSerializerTest.kt
+++ b/kotlin/src/test/kotlin/org/axonframework/extensions/kotlin/serialization/KotlinSerializerTest.kt
@@ -1,0 +1,91 @@
+package org.axonframework.extensions.kotlin.serialization
+
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.JsonElement
+import org.axonframework.serialization.AnnotationRevisionResolver
+import org.axonframework.serialization.ChainingConverter
+import org.axonframework.serialization.SerializedType
+import org.axonframework.serialization.SimpleSerializedObject
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+
+class KotlinSerializerTest {
+
+    /**
+     * This class will automatically become serializable through the Kotlin serialization compiler plugin.
+     */
+    @Serializable
+    data class TestData(
+        val name: String,
+        val value: Float?
+    )
+
+    @Test
+    fun canSerializeTo() {
+        val serializer = kotlinSerializer()
+
+        assertTrue(serializer.canSerializeTo(String::class.java))
+        assertTrue(serializer.canSerializeTo(JsonElement::class.java))
+    }
+
+    @Test
+    fun `configuration options`() {
+        val serializer = kotlinSerializer {
+            json = Json
+            converter = ChainingConverter()
+            revisionResolver = AnnotationRevisionResolver()
+        }
+        assertNotNull(serializer)
+    }
+
+    @Test
+    fun serialize() {
+        val serializer = kotlinSerializer()
+
+        val emptySerialized = serializer.serialize(TestData("", null), String::class.java)
+        assertEquals("SimpleSerializedType[org.axonframework.extensions.kotlin.serialization.KotlinSerializerTest\$TestData] (revision null)", emptySerialized.type.toString())
+        assertEquals("""{"name":"","value":null}""", emptySerialized.data)
+        assertEquals(String::class.java, emptySerialized.contentType)
+
+        val filledSerialized = serializer.serialize(TestData("name", 1.23f), String::class.java)
+        assertEquals("SimpleSerializedType[org.axonframework.extensions.kotlin.serialization.KotlinSerializerTest\$TestData] (revision null)", filledSerialized.type.toString())
+        assertEquals("""{"name":"name","value":1.23}""", filledSerialized.data)
+        assertEquals(String::class.java, filledSerialized.contentType)
+    }
+
+    @Test
+    fun deserialize() {
+        val serializer = kotlinSerializer()
+
+        val nullDeserialized: Any? = serializer.deserialize(SimpleSerializedObject(
+            "",
+            String::class.java,
+            SerializedType.emptyType()
+        ))
+        assertNull(nullDeserialized)
+
+        val emptyDeserialized: Any? = serializer.deserialize(SimpleSerializedObject(
+            """{"name":"","value":null}""",
+            String::class.java,
+            TestData::class.java.name,
+            null
+        ))
+        assertNotNull(emptyDeserialized as TestData)
+        assertEquals(emptyDeserialized.name, "")
+        assertEquals(emptyDeserialized.value, null)
+
+        val filledDeserialized: Any? = serializer.deserialize(SimpleSerializedObject(
+            """{"name":"name","value":1.23}""",
+            String::class.java,
+            TestData::class.java.name,
+            null
+        ))
+        assertNotNull(filledDeserialized as TestData)
+        assertEquals(filledDeserialized.name, "name")
+        assertEquals(filledDeserialized.value, 1.23f)
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -34,8 +34,9 @@
   <properties>
     <axon.version>4.5</axon.version>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <kotlin.version>1.4.32</kotlin.version>
+    <kotlin.version>1.5.0</kotlin.version>
     <kotlin-logging.version>2.0.6</kotlin-logging.version>
+    <kotlin-serialization.version>1.2.1</kotlin-serialization.version>
     <jackson-kotlin.version>2.12.3</jackson-kotlin.version>
     <mockk.version>1.11.0</mockk.version>
     <junit.jupiter.version>5.7.2</junit.jupiter.version>
@@ -128,6 +129,13 @@
       <artifactId>jaxb-api</artifactId>
       <version>2.3.1</version>
       <scope>test</scope>
+    </dependency>
+
+    <!-- Serialization -->
+    <dependency>
+      <groupId>org.jetbrains.kotlinx</groupId>
+      <artifactId>kotlinx-serialization-json</artifactId>
+      <version>${kotlin-serialization.version}</version>
     </dependency>
 
     <!-- Test dependencies -->
@@ -434,6 +442,7 @@
             <compilerPlugins>
               <plugin>no-arg</plugin>
               <plugin>all-open</plugin>
+              <plugin>kotlinx-serialization</plugin>
             </compilerPlugins>
             <pluginOptions>
               <!-- Axon specific classes -->
@@ -475,6 +484,11 @@
             <dependency>
               <groupId>org.jetbrains.kotlin</groupId>
               <artifactId>kotlin-maven-noarg</artifactId>
+              <version>${kotlin.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>org.jetbrains.kotlin</groupId>
+              <artifactId>kotlin-maven-serialization</artifactId>
               <version>${kotlin.version}</version>
             </dependency>
           </dependencies>


### PR DESCRIPTION
This PR adds support for Kotlin serialization, see issue #13.


This PR includes #120 (this is required in order to use the stable version of `kotlin.serialization`).

In summary:
- Adds a class `KotlinSerializer` which implements Axon `Serializer`.
- Configurable `RevisionResolver`, `Converter`, and `Json`, with the same defaults as the Jackson serializer implementation. 
- Because `Json` is configurable, applications can define how JSON should be serialized based on business requirements.
- Adds a DSL function `kotlinSerializer` to create a `KotlinSerializer` with configuration options.
- Useful errors when the `.serializer()` method cannot be found on a companion object of a to-serialize object.
- `Class -> KSerializer` is cached for performance and to avoid too much reflection.
- Simple test to show that the implementation works.

Ref https://kotlinlang.org/docs/serialization.html with basic overview.
Ref https://github.com/Kotlin/kotlinx.serialization/blob/master/docs/serialization-guide.md with serialization guide.
