### PR TITLE
[#286] Add `spring-boot-devtools` support

### DIFF
--- a/kotlin/pom.xml
+++ b/kotlin/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (c) 2010-2022. Axon Framework
+  ~ Copyright (c) 2010-2023. Axon Framework
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
   ~ you may not use this file except in compliance with the License.
@@ -15,7 +15,8 @@
   ~ limitations under the License.
   -->
 
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
   <name>Axon Framework - Kotlin Extension</name>
@@ -39,15 +40,21 @@
       <artifactId>axon-configuration</artifactId>
       <scope>provided</scope>
     </dependency>
-      <dependency>
-          <groupId>io.projectreactor</groupId>
-          <artifactId>reactor-core</artifactId>
-          <version>3.5.5</version>
-          <scope>test</scope>
-      </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <version>3.5.5</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>src/main/resources</directory>
+        <filtering>true</filtering>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.jetbrains.kotlin</groupId>

--- a/kotlin/src/main/resources/META-INF/spring-devtools.properties
+++ b/kotlin/src/main/resources/META-INF/spring-devtools.properties
@@ -1,0 +1,16 @@
+#
+# Copyright (c) 2010-2023. Axon Framework
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+restart.include.axon-kotlin=axon-kotlin-${project.version}.jar


### PR DESCRIPTION
As uncovered in #286, the `applyEvent` extension function does not work as intended when `spring-boot-devtools` is on the classpath of the project.
To fix this, I've included a `spring-devtools.properties` file which includes the `axon-kotlin` modules in its restarts.
To not be required to set a fixed JAR version, I've set resource filtering to `true` in the build settings of the `pom.xml`.