### PR TITLE
Move old docs to library

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,10 +67,10 @@ Are you having trouble using the extension?
 We'd like to help you out the best we can!
 There are a couple of things to consider when you're traversing anything Axon:
 
-* Checking the [reference guide](https://docs.axoniq.io/reference-guide/extensions/kotlin) should be your first stop,
- as the majority of possible scenarios you might encounter when using Axon should be covered there.
+* Checking the [reference guide](https://library.axoniq.io/axon_framework_old_ref/) should be your first stop,
+  as the majority of possible scenarios you might encounter when using Axon should be covered there.
 * If the Reference Guide does not cover a specific topic you would've expected,
- we'd appreciate if you could file an [issue](https://github.com/AxonIQ/reference-guide/issues) about it for us.
+  we'd appreciate if you could post a [new thread/topic on our library fourms describing the problem](https://discuss.axoniq.io/c/26).
 * There is a [forum](https://discuss.axoniq.io/) to support you in the case the reference guide did not sufficiently answer your question.
 Axon Framework and Server developers will help out on a best effort basis.
 Know that any support from contributors on posted question is very much appreciated on the forum.

--- a/docs/_playbook/.gitignore
+++ b/docs/_playbook/.gitignore
@@ -1,0 +1,5 @@
+build
+node_modules
+.vscode
+vale
+package-lock.json

--- a/docs/_playbook/.vale.ini
+++ b/docs/_playbook/.vale.ini
@@ -1,0 +1,24 @@
+StylesPath = vale
+
+MinAlertLevel = suggestion
+
+Packages = http://github.com/AxonIQ/axoniq-vale-package/releases/latest/download/axoniq-vale-package.zip
+
+Vocab = general, AxonIQ, Java, Names_Terms, misc
+
+[*.{adoc,html}]
+BasedOnStyles = AxonIQ, proselint, Google
+
+Google.Headings = NO # Diasable in favor od AxonIQ one
+Google.Parens = NO # Disable warning about using parens
+Google.Quotes = NO # Diasable "commas and periods go inside quotation marks"
+Google.WordList = NO # Disable Google's word list
+Google.Passive = NO # Allow the use of Passive voice
+Google.Colons = NO # Allow the use of Colons
+Google.Will = NO # Allow use will
+Google.Contractions = NO
+Google.We = NO
+
+
+AxonIQ.AcronymCase = NO
+AxonIQ.HeadingTitle = NO

--- a/docs/_playbook/package.json
+++ b/docs/_playbook/package.json
@@ -1,0 +1,11 @@
+{
+  "devDependencies": {
+    "@antora/atlas-extension": "^1.0.0-alpha.2",
+    "@antora/cli": "^3.2.0-alpha.2",
+    "@antora/lunr-extension": "^1.0.0-alpha.8",
+    "@antora/site-generator": "^3.2.0-alpha.2",
+    "@asciidoctor/tabs": "^1.0.0-beta.6",
+    "@axoniq/antora-vale-extension": "^0.1.1",
+    "asciidoctor-kroki": "^0.17.0"
+  }
+}

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -39,4 +39,4 @@ runtime:
 
 ui:
   bundle:
-    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.9/ui-bundle.zip
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.10/ui-bundle.zip

--- a/docs/_playbook/playbook.yaml
+++ b/docs/_playbook/playbook.yaml
@@ -1,0 +1,42 @@
+site:
+  title: Kotlin Extension docs PREVIEW
+  start_page: kotlin_extension_old_ref::index.adoc
+
+content:
+  sources:
+  - url: ../..
+    start_paths: ['docs/*', '!docs/_*']
+
+asciidoc:
+  attributes:
+    experimental: true
+    page-pagination: true
+    kroki-fetch-diagram: true
+  #   primary-site-manifest-url: https://library.axoniq.io/site-manifest.json
+  extensions:
+    - asciidoctor-kroki
+    - '@asciidoctor/tabs'
+
+antora:
+  extensions:
+    - id: prose-linting
+      require: '@axoniq/antora-vale-extension'
+      enabled: true
+      vale_config: .vale.ini
+      update_styles: true
+    - id: lunr
+      require: '@antora/lunr-extension'
+      enabled: true
+      index_latest_only: true
+    - id: atlas
+      require: '@antora/atlas-extension'
+
+runtime:
+  fetch: true # fetch remote repos
+  log:
+    level: info
+    failure_level: error
+
+ui:
+  bundle:
+    url: https://github.com/AxonIQ/axoniq-library-ui/releases/download/v.0.1.9/ui-bundle.zip

--- a/docs/old-reference-guide/antora.yml
+++ b/docs/old-reference-guide/antora.yml
@@ -1,0 +1,14 @@
+name: kotlin_extension_old_ref
+title: Kotlin Extension Guide
+version: true
+prerelease: true
+start_page: ROOT:index.adoc
+
+asciidoc:
+  attributes:
+    component_description: The Kotlin xtension guide from the former reference guide
+    type: guide
+    group: axon-framework
+
+nav:
+  - modules/nav.adoc

--- a/docs/old-reference-guide/modules/ROOT/pages/commands.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/commands.adoc
@@ -1,0 +1,42 @@
+:navtitle: Commands
+= Commands
+
+This section describes the additional functionality attached to Axon's xref:axon_framework_old_ref:axon-framework-commands:README.adoc[command dispatching and handling] logic.
+
+[[commandgateway]]
+== `CommandGateway`
+
+An inlined method has been introduced on the `CommandGateway` which allows the introduction of a dedicated function to be invoked upon success or failure of handling the command. As such it provides a shorthand instead of using the `CommandCallback` directly yourself.
+
+Here is a sample of how this can be utilized within your own project:
+
+[source,kotlin]
+----
+import org.axonframework.commandhandling.CommandMessage
+import org.axonframework.commandhandling.gateway.CommandGateway
+import org.axonframework.messaging.MetaData
+import org.slf4j.LoggerFactory
+
+class CommandDispatcher(private val commandGateway: CommandGateway) {
+
+    private val logger = LoggerFactory.getLogger(CommandDispatcher::class.java)
+
+    // Sample usage providing specific logging logic, next to for example the LoggingInterceptor
+    fun issueCardCommand() {
+        commandGateway.send(
+                command = IssueCardCommand(),
+                onSuccess = { message: CommandMessage<out IssueCardCommand>, result: Any, _: MetaData ->
+                    logger.info("Successfully handled [{}], resulting in [{}]", message, result)
+                },
+                onError = { result: Any, exception: Throwable, _: MetaData ->
+                    logger.warn(
+                            "Failed handling the IssueCardCommand, with output [{} and exception [{}]",
+                            result, exception
+                    )
+                }
+        )
+    }
+}
+
+class IssueCardCommand
+----

--- a/docs/old-reference-guide/modules/ROOT/pages/events.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/events.adoc
@@ -1,0 +1,40 @@
+:navtitle: Events
+= Events
+
+This section describes the additional functionality attached to Axon's xref:axon_framework_old_ref:events:README.adoc[event publication and handling] logic.
+
+== Event upcasters
+
+A simplified implementation of the xref:axon_framework_old_ref:events:event-versioning.adoc#event-upcasting[Single Event Upcaster] is given, which allows for a shorter implementation cycle. Making an upcaster to upcast the `CardIssuedEvent` from revision `0` to `1` can be written as follows:
+
+[source,kotlin]
+----
+import com.fasterxml.jackson.databind.JsonNode
+import org.axonframework.serialization.upcasting.event.SingleEventUpcaster
+
+fun `CardIssuedEvent 0 to 1 Upcaster`(): SingleEventUpcaster =
+        EventUpcaster.singleEventUpcaster(
+                eventType = CardIssuedEvent::class,
+                storageType = JsonNode::class,
+                revisions = Revisions("0", "1")
+        ) { event ->
+            // Perform your upcasting process of the CardIssuedEvent here
+            event
+        }
+
+class CardIssuedEvent
+----
+
+Alternatively, since `Revisions` is essentially a `Pair` of `String`, it is also possible to use link:https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/to.html[Kotlin's `to` function,window=_blank,role=external]:
+
+[source,kotlin]
+----
+EventUpcaster.singleEventUpcaster(
+        eventType = CardIssuedEvent::class,
+        storageType = JsonNode::class,
+        revisions = "0" to "1"
+) { event ->
+    // Perform your upcasting process of the CardIssuedEvent here
+    event
+}
+----

--- a/docs/old-reference-guide/modules/ROOT/pages/index.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/index.adoc
@@ -1,0 +1,14 @@
+:navtitle: Kotlin Extension
+= Kotlin
+
+link:https://kotlinlang.org/[Kotlin,window=_blank,role=external] is a programming language which interoperates fully with Java and the JVM. As Axon is written in Java it can be used in conjunction with Kotlin too, offering a different feel when using the framework.
+
+Some of Axon's API's work perfectly well in Java, but have a rather awkward feel when transitioning over to Kotlin. The goal of the link:https://github.com/AxonFramework/extension-kotlin[Kotlin Extension,window=_blank,role=external] is to remove that awkwardness, by providing link:https://kotlinlang.org/docs/reference/inline-functions.html[inline and reified,window=_blank,role=external] methods of Axon's API.
+
+Several solutions are currently given, which can roughly be segregated into the distinct types of messages used by Axon. This thus provides a xref:commands.adoc[], xref:events.adoc[] and xref:queries.adoc[] section on this guide.
+
+[NOTE]
+.Experimental Release
+====
+Currently, the link:https://github.com/AxonFramework/extension-kotlin[Kotlin Extension,window=_blank,role=external] has been release experimentally (for example, release 0.1.0). This means that all implementations are subject to change until a full release (for example, a release 1.0.0) has been made.
+====

--- a/docs/old-reference-guide/modules/ROOT/pages/queries.adoc
+++ b/docs/old-reference-guide/modules/ROOT/pages/queries.adoc
@@ -1,0 +1,76 @@
+:navtitle: Queries
+= Queries
+
+This section describes the additional functionality attached to Axon's xref:axon_framework_old_ref:queries:README.adoc[query dispatching and handling] logic.
+
+[[querygateway]]
+== `QueryGateway`
+
+Several inlined methods have been introduced on the `QueryGateway` to use generics instead of explicit `Class` objects and `ResponseType` parameters.
+
+[source,kotlin]
+----
+import org.axonframework.queryhandling.QueryGateway
+
+class QueryDispatcher(private val queryGateway: QueryGateway) {
+    fun getTotalNumberOfCards(): Int {
+           val query = CountCardSummariesQuery()
+           // Query will return a CompletableFuture so it has to be handled
+           return queryGateway.query<Int, CountCardSummariesQuery>(query)
+                   .join()
+       }
+}
+
+data class CountCardSummariesQuery(val filter: String = "")
+----
+
+In some cases, Kotlin's type inference system can deduce types without explicit generic parameters. One example of this would be an explicit return parameter:
+
+[source,kotlin]
+----
+import org.axonframework.queryhandling.QueryGateway
+import java.util.concurrent.CompletableFuture
+
+class QueryDispatcher(private val queryGateway: QueryGateway) {
+    fun getTotalNumberOfCards(): CompletableFuture<Int> =
+            queryGateway.query(CountCardSummariesQuery())
+}
+
+data class CountCardSummariesQuery(val filter: String = "")
+----
+
+There are multiple variants of the `query` method provided, for each type of `ResponseType`:
+
+- `query`
+- `queryOptional`
+- `queryMany`
+
+[[queryupdateemitter]]
+== `QueryUpdateEmitter`
+
+An inline `emit` method has been added to `QueryUpdateEmitter` to simplify emit method's call by using generics and moving the lambda predicate at the end of parameter list. This way the lambda function can be moved outside of the parentheses.
+
+[source,kotlin]
+----
+import org.axonframework.queryhandling.QueryUpdateEmitter
+import org.axonframework.eventhandling.EventHandler
+
+class CardSummaryProjection (private val queryUpdateEmitter : QueryUpdateEmitter) {
+    @EventHandler
+    fun on(event : CardIssuedEvent) {
+        // Update projection here
+
+        // Then emit the CountChangedUpdate to subscribers of CountCardSummariesQuery
+        // with the given filter
+        queryUpdateEmitter
+                .emit<CountCardSummariesQuery, CountChangedUpdate>(CountChangedUpdate()) { query ->
+                    // Sample filter based on ID field
+                    event.id.startsWith(query.idFilter)
+                }
+    }
+}
+
+class CardIssuedEvent(val id : String)
+class CountChangedUpdate
+data class CountCardSummariesQuery(val idFilter: String = "")
+----

--- a/docs/old-reference-guide/modules/nav.adoc
+++ b/docs/old-reference-guide/modules/nav.adoc
@@ -1,0 +1,4 @@
+* xref:ROOT:index.adoc[]
+** xref:ROOT:commands.adoc[]
+** xref:ROOT:events.adoc[]
+** xref:ROOT:queries.adoc[]


### PR DESCRIPTION
Moved the contents from the Kotlin Extension docs from the old reference guide in docs.axoniq.io here to be published by antora at library.axoniq.io